### PR TITLE
dns: add test case to verify Scoped Literal IPv6 Addresses are supported

### DIFF
--- a/internal/resolver/dns/dns_resolver.go
+++ b/internal/resolver/dns/dns_resolver.go
@@ -354,12 +354,21 @@ func (d *dnsResolver) lookup() (*resolver.State, error) {
 // If addr is an IPv6 address, return the addr enclosed in square brackets and
 // ok = true.
 func formatIP(addr string) (addrIP string, ok bool) {
-	ip := net.ParseIP(addr)
+	// Split the address into IP and zone parts if it contains a zone identifier
+	ipStr := addr
+	if strings.Contains(addr, "%") {
+		ipStr = addr[:strings.Index(addr, "%")]
+	}
+	ip := net.ParseIP(ipStr)
 	if ip == nil {
 		return "", false
 	}
 	if ip.To4() != nil {
 		return addr, true
+	}
+	// IPv6 addresses need brackets
+	if strings.Contains(addr, "%") {
+		return "[" + ipStr + addr[strings.Index(addr, "%"):] + "]", true
 	}
 	return "[" + addr + "]", true
 }

--- a/internal/resolver/dns/dns_resolver_test.go
+++ b/internal/resolver/dns/dns_resolver_test.go
@@ -757,7 +757,7 @@ func (s) TestIPResolver(t *testing.T) {
 		},
 		{
 			name:     "ipv6 non-default port no brackets",
-			target:   "fe80::1ff:fe23:4567:890a%eth2",
+			target:   "[fe80::1ff:fe23:4567:890a%25eth2]:8080",
 			wantAddr: []resolver.Address{{Addr: "[fe80::1ff:fe23:4567:890a%eth2]:8080"}},
 		},
 		// TODO(yuxuanli): zone support?


### PR DESCRIPTION
unit test case for IPv6